### PR TITLE
Removing links to old data source

### DIFF
--- a/app/charts/templates/charts/merchants.html
+++ b/app/charts/templates/charts/merchants.html
@@ -48,7 +48,7 @@
                 </button>
             </div>
             <div class="modal-body">
-                Merchants accepting a coin. Data from https://acceptedhere.io/stats/<br>
+                Merchants accepting a coin. Data from BTCmap and Monerica<br>
             </div>
             <div class="modal-footer">
                 <button type="button" class="btn btn-secondary" data-dismiss="modal">Close</button>

--- a/app/charts/templates/charts/merchants_increase.html
+++ b/app/charts/templates/charts/merchants_increase.html
@@ -47,7 +47,7 @@
                 </button>
             </div>
             <div class="modal-body">
-                Increase in the number of merchants accepting a coin. Data from https://acceptedhere.io/stats/<br>
+                Increase in the number of merchants accepting a coin. Data from BTCmap and Monerica<br>
             </div>
             <div class="modal-footer">
                 <button type="button" class="btn btn-secondary" data-dismiss="modal">Close</button>

--- a/app/charts/templates/charts/merchants_percentage.html
+++ b/app/charts/templates/charts/merchants_percentage.html
@@ -48,7 +48,7 @@
                 </button>
             </div>
             <div class="modal-body">
-                Increase in percentage of the number of merchants accepting a coin. Data from https://acceptedhere.io/stats/<br>
+                Increase in percentage of the number of merchants accepting a coin. Data from BTCmap and Monerica<br>
             </div>
             <div class="modal-footer">
                 <button type="button" class="btn btn-secondary" data-dismiss="modal">Close</button>


### PR DESCRIPTION
The frontend was still showing the links (URLs) to the old data source "https://acceptedhere.io/stats" which is offline and not used anymore.
Replaced these with "Data from BTCmap and Monerica" (which represents the actual data sources used at the moment).